### PR TITLE
Add missing CacheContext url.query_args to route amazon_product_widget.product_api

### DIFF
--- a/src/Controller/AmazonProductController.php
+++ b/src/Controller/AmazonProductController.php
@@ -65,6 +65,7 @@ class AmazonProductController extends ControllerBase {
 
     $build = $this->getProductService()->buildProducts($entity_type, $entity_id, $fieldname);
     $cache_dependency = CacheableMetadata::createFromRenderArray($build);
+    $cache_dependency->addCacheContexts(['url.query_args']);
 
     $content = $this->renderer->renderRoot($build);
 


### PR DESCRIPTION

Fix issue https://github.com/drunomics/amazon-product-widget/issues/8